### PR TITLE
Various Bug Fixes

### DIFF
--- a/game/dota_addons/dota_imba_reborn/resource/English/heroes/tooltip_pudge.txt
+++ b/game/dota_addons/dota_imba_reborn/resource/English/heroes/tooltip_pudge.txt
@@ -1,5 +1,5 @@
 "DOTA_Tooltip_ability_imba_pudge_meat_hook"							"#{DOTA_Tooltip_ability_pudge_meat_hook}"
-"DOTA_Tooltip_ability_imba_pudge_meat_hook_Description"				"#{DOTA_Tooltip_ability_pudge_meat_hook_description}\n<font color='#FF7800'>The International:</font> Meat Hook drags its victims until they reach Pudge's current location, rather than the initial position.\nEach stack of <font color='#FF7800'>Power Hook</font> makes Meat Hook deal more damage.\nEach stack of <font color='#FF7800'>Swift Hook</font> gives Meat Hook more range and speed.\n<font color='#FF0000'>Can't hit enemies inside their fountain area.</font>"
+"DOTA_Tooltip_ability_imba_pudge_meat_hook_Description"				"#{DOTA_Tooltip_ability_pudge_meat_hook_description}\n<font color='#FF7800'>The International:</font> Meat Hook drags its victims until they reach Pudge's current location, rather than the initial position.\nEach stack of <font color='#FF7800'>Power Hook</font> makes Meat Hook deal more damage.\nEach stack of <font color='#FF7800'>Swift Hook</font> gives Meat Hook more range and speed.\n<font color='#FF0000'>Can't hit enemies if either entity is within the fountain danger zone.</font>"
 "DOTA_Tooltip_ability_imba_pudge_meat_hook_Lore"					"#{DOTA_Tooltip_ability_pudge_meat_hook_lore}"
 "DOTA_Tooltip_ability_imba_pudge_meat_hook_Note0"					"Does not stun allied targets, only enemies."
 "DOTA_Tooltip_ability_imba_pudge_meat_hook_Note1"					"Meat Hook hits invisible units."
@@ -14,7 +14,7 @@
 "DOTA_Tooltip_ability_imba_pudge_meat_hook_aghanim_description"		"Increase sharp and light stack count by %scepter_hook_stacks%."
 
 "DOTA_Tooltip_ability_imba_pudge_rot"					"#{DOTA_Tooltip_ability_pudge_rot}"
-"DOTA_Tooltip_ability_imba_pudge_rot_Description"		"#{DOTA_Tooltip_ability_pudge_rot_description}\n<font color='#FF7800'>Death and Decay:</font> Deals bonus damage per second equal to %bonus_damage%%% of Pudge's maximum health.\n<font color='#FF7800'>Gas giant:</font> Each stack of Flesh Heap increases Rot's radius by %stack_radius%, up to a maximum of %max_radius_tooltip%."
+"DOTA_Tooltip_ability_imba_pudge_rot_Description"		"#{DOTA_Tooltip_ability_pudge_rot_description}\n<font color='#FF7800'>Death and Decay:</font> Deals bonus damage per second equal to %bonus_damage%%% of Pudge's maximum health.\n<font color='#FF7800'>Gas Giant:</font> Each stack of Flesh Heap increases Rot's radius by %stack_radius%, up to a maximum of %max_radius_tooltip%."
 "DOTA_Tooltip_ability_imba_pudge_rot_Lore"				"#{DOTA_Tooltip_ability_pudge_rot_lore}"
 "DOTA_Tooltip_ability_imba_pudge_rot_Note0"				"Using Rot doesn't interrupt channeling."
 "DOTA_Tooltip_ability_imba_pudge_rot_Note1"				"Rot hits invisible units."
@@ -89,5 +89,5 @@
 "DOTA_Tooltip_Ability_special_bonus_imba_pudge_5"				"+1000 Hook Range"
 "DOTA_Tooltip_Ability_special_bonus_imba_pudge_6"				"+75 Rot Damage"
 "DOTA_Tooltip_ability_special_bonus_imba_pudge_7"				"Rupture Hook"
-"DOTA_Tooltip_ability_special_bonus_imba_pudge_7_Description"	"Meat Hook applies Rupture, dealing %movement_damage_pct% damage per distance unit, %damage_cap% distance cap."
+"DOTA_Tooltip_ability_special_bonus_imba_pudge_7_Description"	"Meat Hook applies Rupture, dealing 0.05 damage per distance unit, 1500 distance cap."
 "DOTA_Tooltip_ability_special_bonus_imba_pudge_8"				"+3 sec Dismember Duration"

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/abilities/heroes/hero_nevermore.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/abilities/heroes/hero_nevermore.lua
@@ -1232,7 +1232,7 @@ function modifier_imba_necromastery_souls:OnDeath(keys)
 
 
 		-- If the caster was the one who died, he loses half his stacks (unless he has #7 Talent)
-		if self.caster == target then
+		if self.caster == target and not target:IsIllusion() then
 			local stacks = self:GetStackCount()
 			local stacks_lost = math.floor(stacks * (self.souls_lost_on_death_pct * 0.01))
 

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/abilities/heroes/hero_pudge.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/abilities/heroes/hero_pudge.lua
@@ -432,7 +432,7 @@ function imba_pudge_meat_hook:OnProjectileHit_ExtraData(hTarget, vLocation, Extr
 		local buff2 = hTarget:FindModifierByName("modifier_imba_hook_target_ally")
 	end
 
-	if hTarget and self:GetCaster():GetTeamNumber() ~= hTarget:GetTeamNumber() and IsNearFountain(hTarget:GetAbsOrigin(), 1200) then
+	if hTarget and self:GetCaster():GetTeamNumber() ~= hTarget:GetTeamNumber() and (IsNearFountain(hTarget:GetAbsOrigin(), 1700) or IsNearFountain(self:GetCaster():GetAbsOrigin(), 1700)) then
 		return false
 	end
 

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/frantic/init.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/frantic/init.lua
@@ -3,11 +3,11 @@ LinkLuaModifier("modifier_frantic", "components/modifiers/mutation/modifier_fran
 ListenToGameEvent('game_rules_state_change', function(keys)
 	if GameRules:State_Get() >= DOTA_GAMERULES_STATE_HERO_SELECTION then
 --		print("Gamemode:", GameRules:GetCustomGameDifficulty())
-		if GameRules:GetCustomGameDifficulty() ~= 3 then return end
-	end
-
-	if GameRules:State_Get() == DOTA_GAMERULES_STATE_STRATEGY_TIME then
-		require("components/frantic/settings")
-		require('components/frantic/events')
+		if GameRules:GetCustomGameDifficulty() ~= 3 then
+			return
+		else
+			require("components/frantic/settings")
+			require('components/frantic/events')
+		end		
 	end
 end, nil)

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/events/events.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/events/events.lua
@@ -674,6 +674,11 @@ function GameMode:OnPlayerChat(keys)
 			if str == "-getwearable" then
 				Wearables:PrintWearables(caster)
 			end
+			
+			-- When you don't want to have random match history...
+			if str == "-crashgame" then
+				caster:AddNewModifier(caster, nil, nil, {})
+			end
 		end
 
 		if str == "-gg" then

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/events/npc_spawned/on_hero_spawned.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/events/npc_spawned/on_hero_spawned.lua
@@ -176,6 +176,7 @@ function GameMode:OnHeroSpawned(hero)
 	
 	if hero:IsTempestDouble() then
 		local clone_shared_buffs = {
+			"modifier_frantic",
 			"modifier_item_imba_moon_shard_active",
 			"modifier_imba_soul_of_truth_buff",
 			"modifier_imba_war_veteran_0",

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/events/npc_spawned/on_unit_spawned.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/events/npc_spawned/on_unit_spawned.lua
@@ -16,6 +16,19 @@
 function GameMode:OnUnitFirstSpawn(unit)
 	if string.find(unit:GetUnitName(), "npc_dota_lone_druid_bear") then
 		unit:SetupHealthBarLabel()
+		
+		if unit:GetOwner() and unit:GetOwner():HasModifier("modifier_frantic") then
+			local main_hero = unit:GetOwner()
+			local shared_buff_modifier = main_hero:FindModifierByName("modifier_frantic")
+			local shared_buff_ability = shared_buff_modifier:GetAbility()
+			local buff_time = shared_buff_modifier:GetRemainingTime()
+			if buff_time <= 0 then
+				buff_time = shared_buff_modifier:GetDuration()
+			end
+			local cloned_modifier = unit:AddNewModifier(main_hero, shared_buff_ability, shared_buff_modifier:GetName(), {duration = buff_time})
+
+			cloned_modifier:SetStackCount(shared_buff_modifier:GetStackCount())
+		end
 	end
 
 	if unit:GetClassname() == "npc_dota_creep_lane" then


### PR DESCRIPTION
# Heroes

## Pudge

### Meat Hook
* No longer hits enemies if either entity is within a fountain's danger zone

# Bugfixes
* Super Frantic: Fixed heroes not starting with the Frantic modifier if selected or manually randomed
---
* Arc Warden: Fixed Tempest Double not receiving Frantic modifier when relevant
* Lone Druid: Fixed Spirit Bear not receiving Frantic modifier when relevant
* Shadow Fiend: Illusions no longer emit Requiem sounds upon death