### PR TITLE
Minor mechanic tweak for blazing fire.

### DIFF
--- a/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_lina.lua
+++ b/game/dota_addons/dota_imba/scripts/vscripts/hero/hero_lina.lua
@@ -70,14 +70,14 @@ end
 
 function modifier_imba_blazing_fire:OnIntervalThink( )
 	if IsServer() then
-		ApplyDamage({victim = self:GetParent(), attacker = self:GetCaster(), ability = nil, damage = self.dmg_per_tick, damage_type = DAMAGE_TYPE_MAGICAL})
+		ApplyDamage({victim = self:GetParent(), attacker = self:GetCaster(), ability = nil, damage = self.dmg_per_tick, damage_type = DAMAGE_TYPE_PURE})
 		self.counter = self.counter - 1
 	end
 end
 
 function modifier_imba_blazing_fire:OnDestroy( params )
 	if IsServer() then
-		ApplyDamage({victim = self:GetParent(), attacker = self:GetCaster(), ability = nil, damage = (self.dmg_per_tick * self.counter), damage_type = DAMAGE_TYPE_MAGICAL})
+		ApplyDamage({victim = self:GetParent(), attacker = self:GetCaster(), ability = nil, damage = (self.dmg_per_tick * self.counter), damage_type = DAMAGE_TYPE_PURE})
 		ParticleManager:DestroyParticle(self.particle_fx, false)
 		ParticleManager:ReleaseParticleIndex(self.particle_fx)
 	end
@@ -808,6 +808,7 @@ function modifier_imba_fiery_soul_blaze_burn:OnIntervalThink()
 		if fiery_soul_counter then
 			local damage = fiery_soul_counter:GetStackCount() * self.caster:FindTalentValue("special_bonus_imba_lina_5")
 			ApplyDamage({attacker = self.caster, victim = self.parent, ability = self.ability, damage = damage, damage_type = self.ability:GetAbilityDamageType()})
+			self.parent:RemoveModifierByName("modifier_imba_blazing_fire")
 		end
 	end
 end


### PR DESCRIPTION
Suggested lategame change to make blazing fire epic again. 

1 ) 
Considering how hard it is to scale this DoT (basicly hardcapped at 60dps) its more then fair that the value you see in the tooltip is what you deal as damage. i.e 10% of int per tick.

2 )
Add synergy between Lina's lvl 15 talent (Spells deal damage over time) and lvl 25 talent Blazing Fire. 
Each tick of the spells DoT will now proc Blazing Fire.
