### PR TITLE
fixing volvo math

### DIFF
--- a/game/dota_addons/dota_imba_reborn/scripts/npc/npc_abilities_override.txt
+++ b/game/dota_addons/dota_imba_reborn/scripts/npc/npc_abilities_override.txt
@@ -5051,7 +5051,7 @@
 		{
 			"01"
 			{
-				"var_type"									"FIELD_INTEGER"
+				"var_type"									"FIELD_FLOAT"
 				"illusion_duration"							"34 36 38 40"
 			}
 			"02"

--- a/game/dota_addons/dota_imba_reborn/scripts/npc/npc_abilities_override.txt
+++ b/game/dota_addons/dota_imba_reborn/scripts/npc/npc_abilities_override.txt
@@ -5052,7 +5052,7 @@
 			"01"
 			{
 				"var_type"									"FIELD_FLOAT"
-				"illusion_duration"							"34 36 38 40"
+				"illusion_duration"							"34.0 36.0 38.0 40.0"
 			}
 			"02"
 			{


### PR DESCRIPTION
TB illusions have 0s duration (before picking the proper talent), probably because of 7.26b vanilla talents updates (now talent +8 duration is a float). This should fix this, but I don't know how to test this in-game.