### PR TITLE
Fixing(?) wisp relocate

### DIFF
--- a/game/dota_addons/dota_imba_reborn/scripts/npc/heroes/wisp/abilities.txt
+++ b/game/dota_addons/dota_imba_reborn/scripts/npc/heroes/wisp/abilities.txt
@@ -496,7 +496,7 @@
 			"02"
 			{
 				"var_type"					"FIELD_FLOAT"
-				"return_time"				"12.0"
+				"return_time"				"12.0 12.0 12.0"
 			}
 			"03"
 			{


### PR DESCRIPTION
Relocate doesn't work (just put the ability on cooldown). Change values to the vanilla version.