### PR TITLE
Heart creep hero fix

### DIFF
--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/items/item_heart.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/items/item_heart.lua
@@ -123,7 +123,7 @@ end
 
 function modifier_item_imba_heart:OnTakeDamage(keys)
 	-- "Damage greater than 0 from any player (including allies, excluding self) or Roshan puts the regeneration on a 5/7-second cooldown. "
-	if self:GetAbility() and self:GetAbility():GetSecondaryCharges() == 1 and keys.unit == self:GetParent() and keys.damage > 0 and keys.attacker ~= keys.unit and (keys.attacker:IsHero() or keys.attacker:IsRoshan()) and bit.band(keys.damage_flags, DOTA_DAMAGE_FLAG_HPLOSS) ~= DOTA_DAMAGE_FLAG_HPLOSS then
+	if self:GetAbility() and self:GetAbility():GetSecondaryCharges() == 1 and keys.unit == self:GetParent() and keys.damage > 0 and keys.attacker ~= keys.unit and (keys.attacker:IsHero() or keys.attacker:IsCreepHero() or keys.attacker:IsRoshan()) and bit.band(keys.damage_flags, DOTA_DAMAGE_FLAG_HPLOSS) ~= DOTA_DAMAGE_FLAG_HPLOSS then
 		if self:GetParent():IsRangedAttacker() then
 			self:GetAbility():StartCooldown(self:GetAbility():GetSpecialValueFor("regen_cooldown_ranged") * self:GetParent():GetCooldownReduction())
 		else

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/items/item_heart.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/items/item_heart.lua
@@ -123,7 +123,7 @@ end
 
 function modifier_item_imba_heart:OnTakeDamage(keys)
 	-- "Damage greater than 0 from any player (including allies, excluding self) or Roshan puts the regeneration on a 5/7-second cooldown. "
-	if self:GetAbility() and self:GetAbility():GetSecondaryCharges() == 1 and keys.unit == self:GetParent() and keys.damage > 0 and keys.attacker ~= keys.unit and (keys.attacker:IsHero() or keys.attacker:IsCreepHero() or keys.attacker:IsRoshan()) and bit.band(keys.damage_flags, DOTA_DAMAGE_FLAG_HPLOSS) ~= DOTA_DAMAGE_FLAG_HPLOSS then
+	if self:GetAbility() and self:GetAbility():GetSecondaryCharges() == 1 and keys.unit == self:GetParent() and keys.damage > 0 and keys.attacker ~= keys.unit and (keys.attacker:IsHero() or keys.attacker:IsConsideredHero() or keys.attacker:IsRoshan()) and bit.band(keys.damage_flags, DOTA_DAMAGE_FLAG_HPLOSS) ~= DOTA_DAMAGE_FLAG_HPLOSS then
 		if self:GetParent():IsRangedAttacker() then
 			self:GetAbility():StartCooldown(self:GetAbility():GetSpecialValueFor("regen_cooldown_ranged") * self:GetParent():GetCooldownReduction())
 		else

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/libraries/player.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/libraries/player.lua
@@ -1028,12 +1028,6 @@ function CDOTA_BaseNPC:IsRealHero()
 	end
 end
 
-function CDOTA_BaseNPC:IsCreepHero()
-	if not self:IsNull() then
-		return self:GetClassname() == "npc_dota_lone_druid_bear" or string.find(self:GetUnitName(), "warlock_golem") or self:GetName() == "npc_dota_visage_familiar" or self:GetName() == "npc_dota_elder_titan_ancestral_spirit" or self:GetName() == "npc_dota_brewmaster_earth" or self:GetName() == "npc_dota_brewmaster_fire" or self:GetName() == "npc_dota_brewmaster_storm"
-	end
-end
-
 function CDOTA_BaseNPC:Blink(position, bTeamOnlyParticle, bPlaySound)
 	if self:IsNull() then return end
 

--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/libraries/player.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/libraries/player.lua
@@ -1028,6 +1028,12 @@ function CDOTA_BaseNPC:IsRealHero()
 	end
 end
 
+function CDOTA_BaseNPC:IsCreepHero()
+	if not self:IsNull() then
+		return self:GetClassname() == "npc_dota_lone_druid_bear" or string.find(self:GetUnitName(), "warlock_golem") or self:GetName() == "npc_dota_visage_familiar" or self:GetName() == "npc_dota_elder_titan_ancestral_spirit" or self:GetName() == "npc_dota_brewmaster_earth" or self:GetName() == "npc_dota_brewmaster_fire" or self:GetName() == "npc_dota_brewmaster_storm"
+	end
+end
+
 function CDOTA_BaseNPC:Blink(position, bTeamOnlyParticle, bPlaySound)
 	if self:IsNull() then return end
 


### PR DESCRIPTION
Heart of Tarrasque is disabled by creep-hero type units in vanilla, but not in imba.

This fixes Heart of Tarrasque not being disabled by creep-hero type units.