### PR TITLE
Hellion's ulti now does not pierce magic immunity.

### DIFF
--- a/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/abilities/heroes/hero_hell_empress.lua
+++ b/game/dota_addons/dota_imba_reborn/scripts/vscripts/components/abilities/heroes/hero_hell_empress.lua
@@ -255,7 +255,7 @@ function imba_empress_hurl_through_hell:OnSpellStart()
 	ParticleManager:ReleaseParticleIndex(cast_pfx)
 
 	-- Iterate through caught enemies
-	local enemies = FindUnitsInRadius(caster:GetTeamNumber(), target_loc, nil, hurl_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_MAGIC_IMMUNE_ENEMIES, FIND_ANY_ORDER, false)
+	local enemies = FindUnitsInRadius(caster:GetTeamNumber(), target_loc, nil, hurl_radius, DOTA_UNIT_TARGET_TEAM_ENEMY, DOTA_UNIT_TARGET_HERO + DOTA_UNIT_TARGET_BASIC, DOTA_UNIT_TARGET_FLAG_NONE, FIND_ANY_ORDER, false)
 	for _, enemy in pairs(enemies) do
 
 		-- Apply banishment modifier


### PR DESCRIPTION
Hellion's ulti now does not pierce magic immunity. But debuffs are still unpurgable by magic immunity.